### PR TITLE
Add public-facing GitHub Copilot Canada resource hub

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link.md
+++ b/.github/ISSUE_TEMPLATE/broken-link.md
@@ -1,0 +1,26 @@
+---
+name: 🛠 Report a broken link
+about: Report a link in the hub that no longer works
+title: "[Broken link] <short description>"
+labels: ["broken-link", "needs-triage"]
+assignees: []
+---
+
+## Where is the broken link?
+
+**File / page:** <!-- e.g. `README.md`, `CONTRIBUTING.md`, `SUPPORT.md` -->
+**Section:**
+**Link text:**
+**URL:**
+
+## What happens when you follow it?
+
+<!-- e.g. 404, redirects to a login wall, page exists but content is gone, etc. -->
+
+## Suggested replacement (if known)
+
+<!-- A working URL for the same resource, an archived copy, or "remove the link". -->
+
+## Additional context
+
+<!-- Anything else that helps us triage faster. -->

--- a/.github/ISSUE_TEMPLATE/suggest-resource.md
+++ b/.github/ISSUE_TEMPLATE/suggest-resource.md
@@ -1,0 +1,48 @@
+---
+name: 🔗 Suggest a resource
+about: Suggest a new GitHub Copilot resource to add to the hub
+title: "[Suggest] <resource name>"
+labels: ["suggestion", "needs-triage"]
+assignees: []
+---
+
+## Resource
+
+**Name:**
+**URL:**
+**One-line description:**
+
+## Where should it live?
+
+Pick the README section you think fits best (or suggest a new one):
+
+- [ ] Canada Events
+- [ ] Learning & Skilling
+- [ ] Developer Enablement
+- [ ] What's New
+- [ ] Governance & Architecture
+- [ ] CSI Resources
+- [ ] Other / new section — please describe:
+
+## Audience
+
+Who is this resource most useful for? *(check all that apply)*
+
+- [ ] Customers
+- [ ] Developers
+- [ ] Decision-makers (IT leaders, security, procurement)
+- [ ] Microsoft account teams
+
+## Why does it belong in this hub?
+
+<!-- A sentence or two on why this is a high-signal addition for the Canadian
+GitHub Copilot community. -->
+
+## Access / availability
+
+- [ ] Publicly accessible (no login required)
+- [ ] Requires a free account (e.g. github.com, learn.microsoft.com)
+- [ ] Other — please describe:
+
+> **Note:** Resources requiring Microsoft corporate SSO or internal-only access
+> belong on the internal SharePoint companion, not in this public hub.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Linux
+*~
+.Trash-*
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Local notes / drafts
+/scratch/
+/drafts/
+*.local.md
+
+# Node (in case anyone adds tooling later, e.g. link checker)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Python (same rationale)
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Environment / secrets
+.env
+.env.*
+!.env.example

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS for microsoft/github-copilot-canada
+#
+# Each line is a file pattern followed by one or more owners. The last
+# matching pattern wins. See:
+# https://docs.github.com/articles/about-code-owners
+#
+# This file is intentionally inert (everything commented out) so PRs are not
+# blocked while the owning GitHub team is being provisioned. Uncomment and
+# replace the placeholder team handle below once the team handle is final.
+
+# Default owners for everything in the repo
+# *       @microsoft/ghcp-canada-maintainers

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Thanks for helping make this hub better! This repository is a curated collection
-of GitHub Copilot resources for our Canadian customer, developer, and
+of GitHub Copilot resources for our Canadian customers, developer, and
 decision-maker community. Contributions of new resources, fixes to broken links,
 and improvements to descriptions are all welcome.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for helping make this hub better! This repository is a curated collection
+of GitHub Copilot resources for our Canadian customer, developer, and
+decision-maker community. Contributions of new resources, fixes to broken links,
+and improvements to descriptions are all welcome.
+
+## Ways to contribute
+
+### 🔗 Suggest a new resource
+
+Have a session recording, blog post, customer story, or learning path that
+belongs here? Open an issue using the **Suggest a resource** template, or send
+a pull request that adds the link to the relevant section.
+
+### 🛠 Report a broken link
+
+If you find a link that no longer works, please open an issue using the
+**Report a broken link** template. PRs that fix broken links are also welcome.
+
+### ✏️ Improve existing content
+
+Typo, unclear description, or out-of-date information? PRs are welcome.
+
+## How to submit a pull request
+
+1. Fork the repository.
+2. Create a topic branch (`git checkout -b suggest/awesome-resource`).
+3. Make your change. Keep PRs focused — one resource or topic per PR is ideal.
+4. Use the established formatting:
+   `**Resource name** — one-line description. [Link](https://example.com)`
+5. Commit and push your branch, then open a PR against `main`.
+6. A maintainer from the GitHub Copilot Canada team will review.
+
+## What belongs here
+
+✅ Public, freely accessible GitHub Copilot resources relevant to Canadian
+customers, developers, and decision-makers (events, learning, governance,
+documentation, customer stories).
+
+✅ Microsoft-published or GitHub-published material.
+
+✅ Community resources that meet a high quality bar.
+
+❌ Internal-only Microsoft material (links requiring corporate SSO, internal
+SharePoint, etc.). That content lives on the internal SharePoint companion
+to this hub.
+
+❌ Resources unrelated to GitHub Copilot or to enterprise adoption thereof.
+
+## Microsoft Contributor License Agreement
+
+Most contributions require you to agree to a Microsoft Contributor License
+Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit
+<https://cla.opensource.microsoft.com>.
+
+When you submit a pull request, a CLA bot will automatically determine whether
+you need to provide a CLA and decorate the PR appropriately. Simply follow the
+instructions provided by the bot. You will only need to do this once across all
+repositories using our CLA.
+
+## Code of Conduct
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
+additional questions or comments.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,21 @@
-    MIT License
+MIT License
 
-    Copyright (c) Microsoft Corporation.
+Copyright (c) Microsoft Corporation.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,150 @@
-# Repository setup required :wave:
-    
-Please visit the website URL :point_right: for this repository to complete the setup of this repository and configure access controls.
+# 🇨🇦 GitHub Copilot Canada
+
+A curated public hub of GitHub Copilot resources for Canadian customers,
+developers, and decision-makers — maintained by the **GitHub Copilot Canada
+team at Microsoft**.
+
+This is the single landing page for events, learning paths, developer
+enablement, governance guidance, and account-specific resources. Everything
+here is publicly accessible — no login required.
+
+---
+
+## Who this is for
+
+| 🧭 Customers | 💻 Developers | 🏛 Decision-makers |
+|---|---|---|
+| Find Canadian events, customer stories, and the fastest path to value with Copilot. Start with [Canada Events](#-canada-events) and [Learning & Skilling](#-learning--skilling). | Hands-on tutorials, labs, and the latest changelog so you can build with Copilot today. Start with [Learning & Skilling](#-learning--skilling) and [Developer Enablement](#-developer-enablement). | Architecture, governance, and adoption guidance for IT, security, and procurement leaders. Start with [Governance & Architecture](#-governance--architecture). |
+
+---
+
+## 📅 Canada Events
+
+Live and upcoming events run by — or featuring — the GitHub Copilot Canada team.
+
+- **GHCP Dev Days Canada** — Microsoft and GitHub's Canada-focused Copilot
+  developer event series. [aka.ms/ghcp-dev-days-canada](https://aka.ms/ghcp-dev-days-canada)
+- **Development Enablement Series — AI Coding with GitHub Copilot** — A
+  multi-part enablement series for engineering teams adopting Copilot in
+  Canada. *Registration link will be added here once published.*
+
+---
+
+## 📚 Learning & Skilling
+
+Self-paced learning paths, hands-on labs, official documentation, and video
+content for getting productive with GitHub Copilot.
+
+### Self-paced & curated
+- **Awesome Copilot — Learning Hub** — Structured learning paths for every
+  level of Copilot user. [awesome-copilot.github.com/learning-hub](https://awesome-copilot.github.com/learning-hub/)
+- **Awesome Copilot (site)** — Community-curated index of the best Copilot
+  prompts, instructions, chat modes, and extensions.
+  [awesome-copilot.github.com](https://awesome-copilot.github.com/)
+- **Awesome Copilot (repo)** — Source repo for the above, where contributions
+  happen. [github.com/github/awesome-copilot](https://github.com/github/awesome-copilot)
+
+### Hands-on
+- **GitHub Copilot Tutorials** — Official short-form tutorials, organized by
+  scenario and language. [docs.github.com/en/copilot/tutorials](https://docs.github.com/en/copilot/tutorials)
+- **GitHub Copilot Labs (Microsoft Learn)** — Step-by-step lab environment
+  for developers learning Copilot.
+  [microsoftlearning.github.io/mslearn-github-copilot-dev](https://microsoftlearning.github.io/mslearn-github-copilot-dev/)
+
+### Reference
+- **GitHub Documentation** — The full GitHub product documentation, including
+  Copilot. [docs.github.com](https://docs.github.com/en)
+
+### Video
+- **GitHub Upskilling Playlists on YouTube** — Official GitHub channel with
+  Copilot deep-dives, demos, and conference talks.
+  [youtube.com/@GitHub/playlists](https://www.youtube.com/@GitHub/playlists)
+
+---
+
+## 🛠 Developer Enablement
+
+Programs and content designed to help engineering teams adopt and scale
+GitHub Copilot.
+
+- **AI Coding with GitHub Copilot** — A Development Enablement Series for
+  Canadian engineering teams. Sessions cover prompt patterns, chat modes,
+  agentic workflows, code review, and team-scale adoption.
+  *(See [Canada Events](#-canada-events) for upcoming sessions; registration
+  link will be added here once published.)*
+
+---
+
+## 📰 What's New
+
+- **GitHub Changelog** — Authoritative source for everything that ships
+  across GitHub and Copilot. [github.blog/changelog](https://github.blog/changelog/)
+
+---
+
+## 🏛 Governance & Architecture
+
+For organizations adopting Copilot at scale — patterns, guardrails, and
+reference architectures.
+
+- **Agentic Governance (Microsoft APM)** — The Agentic Project Management
+  framework from Microsoft for governing teams of AI agents at enterprise
+  scale. [github.com/microsoft/apm](https://github.com/microsoft/apm)
+- **GitHub Well-Architected Framework** — GitHub's official guidance for
+  building well-architected systems on the GitHub platform, including
+  Copilot. [wellarchitected.github.com](https://wellarchitected.github.com/)
+
+---
+
+## 🤝 CSI Resources
+
+A dedicated space for Copilot resources tailored to **CSI** (Canadian
+Strategic / large-account engagements). Content will be expanded in this
+section as it becomes available — start with the global resources above
+in the meantime.
+
+---
+
+## 💬 Get in Touch
+
+- **Open an issue** on this repository to suggest a resource, report a
+  broken link, or request that a new topic be covered. See the
+  [issue templates](.github/ISSUE_TEMPLATE) and [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Through your Microsoft account team** — if you already work with a
+  Microsoft account team, they can route you to the GitHub Copilot Canada
+  team directly.
+- A direct engagement channel (email alias / Teams) for the GHCP Canada
+  team will be added here once finalized.
+
+---
+
+## 🔒 Security, Trust & Compliance
+
+For information about reporting security vulnerabilities, see
+[SECURITY.md](SECURITY.md). For broader GitHub trust, security, and
+compliance documentation, visit
+[GitHub Trust Center](https://github.com/trust-center) and
+[GitHub Copilot Trust Center](https://resources.github.com/copilot-trust-center/).
+
+---
+
+## 🛠 Contributing
+
+Suggestions, broken-link reports, and improvements are welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to propose a new resource or
+file a fix. By participating, you agree to abide by the
+[Microsoft Open Source Code of Conduct](CODE_OF_CONDUCT.md).
+
+For Microsoft employees: an internal companion site for GitHub Copilot
+Canada is coming soon and will be linked here once published.
+
+---
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or
+services. Authorized use of Microsoft trademarks or logos is subject to
+and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project
+must not cause confusion or imply Microsoft sponsorship. Any use of
+third-party trademarks or logos is subject to those third parties' policies.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# Support
+
+## How to file issues and get help
+
+This project uses **GitHub Issues** to track broken links, suggest new
+resources, and surface improvements to the hub. Please search the
+[existing issues](https://github.com/microsoft/github-copilot-canada/issues)
+before filing a new one to avoid duplicates.
+
+- 🔗 **Suggest a new resource** — use the *Suggest a resource* issue template.
+- 🛠 **Report a broken link** — use the *Report a broken link* issue template.
+- 💬 **Questions about a resource itself** (e.g. content questions about an
+  event, tutorial, or playbook) — please reach out to the resource's owner
+  directly. This hub curates links; it does not own the underlying content.
+
+## Getting help with GitHub Copilot
+
+This repository does **not** provide product support for GitHub Copilot itself.
+For Copilot product issues:
+
+- **Documentation:** <https://docs.github.com/en/copilot>
+- **GitHub Support:** <https://support.github.com/>
+- **GitHub Community:** <https://github.com/orgs/community/discussions>
+- **Status:** <https://www.githubstatus.com/>
+
+## Engaging the GitHub Copilot Canada team
+
+The team will publish a direct engagement channel (email alias / Teams channel)
+in this file as soon as one is finalized. In the meantime, please open an
+issue on this repository or reach out through your existing Microsoft account
+team.
+
+## Microsoft Support Policy
+
+Support for this hub is limited to the resources listed above. The hub itself
+is maintained by the GitHub Copilot Canada team at Microsoft on a best-effort
+basis.


### PR DESCRIPTION
Replace the placeholder repository with a single-page curated public hub for Canadian customers, developers, and decision-makers exploring or adopting GitHub Copilot.

- README organized by audience track (Customers / Developers / Decision-makers) with sections for Canada Events, Learning & Skilling, Developer Enablement, What's New, Governance & Architecture, CSI Resources, Get in Touch, Security & Trust, Contributing, and a Trademarks footer.
- Microsoft public-repo standard files: LICENSE (MIT), CODE_OF_CONDUCT.md, CONTRIBUTING.md, SUPPORT.md, CODEOWNERS (inert placeholder so PRs aren't blocked), and .gitignore.
- Issue templates for suggesting a new resource and reporting a broken link.

All external links verified (HTTP 200). SECURITY.md left unchanged.