### PR TITLE
Slim README and add UBB section + Canada events form, APM docs, conta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
+<div align="center">
+<img width="474" height="138" alt="ms+gh" src="https://github.com/user-attachments/assets/fcd7622d-50bd-4080-8361-27add0d3e650" /> <img width="1400" height="350" alt="ghcp_li_banner" src="https://github.com/user-attachments/assets/0b6111a5-cc00-4680-af45-1427869f7db0" />
+</div>
+
 # 🇨🇦 GitHub Copilot Canada
 
-A curated public hub of GitHub Copilot resources for Canadian customers,
-developers, and decision-makers — maintained by the **GitHub Copilot Canada
-team at Microsoft**.
-
-This is the single landing page for events, learning paths, developer
-enablement, governance guidance, and account-specific resources. Everything
-here is publicly accessible — no login required.
+> A curated public hub of GitHub Copilot resources for Canadian customers, developers, and decision-makers — maintained by the **GitHub Copilot Canada team at Microsoft**.
 
 ---
 
@@ -14,137 +12,68 @@ here is publicly accessible — no login required.
 
 | 🧭 Customers | 💻 Developers | 🏛 Decision-makers |
 |---|---|---|
-| Find Canadian events, customer stories, and the fastest path to value with Copilot. Start with [Canada Events](#-canada-events) and [Learning & Skilling](#-learning--skilling). | Hands-on tutorials, labs, and the latest changelog so you can build with Copilot today. Start with [Learning & Skilling](#-learning--skilling) and [Developer Enablement](#-developer-enablement). | Architecture, governance, and adoption guidance for IT, security, and procurement leaders. Start with [Governance & Architecture](#-governance--architecture). |
+| Events & customer stories → [Canada Events](#-canada-events) | Tutorials, labs & changelog → [Learning & Skilling](#-learning--skilling) | Architecture & governance → [Governance & Architecture](#-governance--architecture) |
 
 ---
 
 ## 📅 Canada Events
 
-Live and upcoming events run by — or featuring — the GitHub Copilot Canada team.
+- **GHCP Dev Days Canada 🇨🇦** — Microsoft and GitHub's Canada-focused Copilot developer event series. [aka.ms/ghcp-dev-days-canada](https://aka.ms/ghcp-dev-days-canada)
+- **[AI Coding with GitHub Copilot — Development Enablement Series](https://proud-pebble-09ba52a0f.6.azurestaticapps.net/)** — Multi-part series for Canadian engineering teams covering prompt patterns, chat modes, agentic workflows, code review, and team-scale adoption.
+- **Apply for workshops, office hours & invite-only events** — Get on the GHCP Canada team's invite list. [aka.ms/ghcp-canada-events-form](https://aka.ms/ghcp-canada-events-form)
 
-- **GHCP Dev Days Canada** — Microsoft and GitHub's Canada-focused Copilot
-  developer event series. [aka.ms/ghcp-dev-days-canada](https://aka.ms/ghcp-dev-days-canada)
-- **Development Enablement Series — AI Coding with GitHub Copilot** — A
-  multi-part enablement series for engineering teams adopting Copilot in
-  Canada. *Registration link will be added here once published.*
+
 
 ---
 
 ## 📚 Learning & Skilling
 
-Self-paced learning paths, hands-on labs, official documentation, and video
-content for getting productive with GitHub Copilot.
+#### Self-paced & curated
+- **Awesome Copilot — Learning Hub** — Structured learning paths for every level. [awesome-copilot.github.com/learning-hub](https://awesome-copilot.github.com/learning-hub/)
+- **Awesome Copilot (site)** — Community-curated index of prompts, instructions, chat modes, and extensions. [awesome-copilot.github.com](https://awesome-copilot.github.com/)
+- **Awesome Copilot (repo)** — Source repo for the above. [github.com/github/awesome-copilot](https://github.com/github/awesome-copilot)
 
-### Self-paced & curated
-- **Awesome Copilot — Learning Hub** — Structured learning paths for every
-  level of Copilot user. [awesome-copilot.github.com/learning-hub](https://awesome-copilot.github.com/learning-hub/)
-- **Awesome Copilot (site)** — Community-curated index of the best Copilot
-  prompts, instructions, chat modes, and extensions.
-  [awesome-copilot.github.com](https://awesome-copilot.github.com/)
-- **Awesome Copilot (repo)** — Source repo for the above, where contributions
-  happen. [github.com/github/awesome-copilot](https://github.com/github/awesome-copilot)
+#### Hands-on
+- **GitHub Copilot Tutorials** — Official short-form tutorials by scenario and language. [docs.github.com/en/copilot/tutorials](https://docs.github.com/en/copilot/tutorials)
+- **GitHub Copilot Labs (Microsoft Learn)** — Step-by-step lab environment. [microsoftlearning.github.io/mslearn-github-copilot-dev](https://microsoftlearning.github.io/mslearn-github-copilot-dev/)
 
-### Hands-on
-- **GitHub Copilot Tutorials** — Official short-form tutorials, organized by
-  scenario and language. [docs.github.com/en/copilot/tutorials](https://docs.github.com/en/copilot/tutorials)
-- **GitHub Copilot Labs (Microsoft Learn)** — Step-by-step lab environment
-  for developers learning Copilot.
-  [microsoftlearning.github.io/mslearn-github-copilot-dev](https://microsoftlearning.github.io/mslearn-github-copilot-dev/)
+#### Reference
+- **GitHub Documentation** — Full GitHub product documentation, including Copilot. [docs.github.com](https://docs.github.com/en)
+- **GitHub Changelog** — Authoritative source for everything that ships across GitHub and Copilot. [github.blog/changelog](https://github.blog/changelog/)
 
-### Reference
-- **GitHub Documentation** — The full GitHub product documentation, including
-  Copilot. [docs.github.com](https://docs.github.com/en)
-
-### Video
-- **GitHub Upskilling Playlists on YouTube** — Official GitHub channel with
-  Copilot deep-dives, demos, and conference talks.
-  [youtube.com/@GitHub/playlists](https://www.youtube.com/@GitHub/playlists)
+#### Video
+- **GitHub Upskilling Playlists on YouTube** — Official GitHub channel with Copilot deep-dives, demos, and conference talks. [youtube.com/@GitHub/playlists](https://www.youtube.com/@GitHub/playlists)
 
 ---
 
-## 🛠 Developer Enablement
+## 💳 Usage-Based Billing (UBB)
 
-Programs and content designed to help engineering teams adopt and scale
-GitHub Copilot.
+Resources about Copilot's move to usage-based billing.
 
-- **AI Coding with GitHub Copilot** — A Development Enablement Series for
-  Canadian engineering teams. Sessions cover prompt patterns, chat modes,
-  agentic workflows, code review, and team-scale adoption.
-  *(See [Canada Events](#-canada-events) for upcoming sessions; registration
-  link will be added here once published.)*
-
----
-
-## 📰 What's New
-
-- **GitHub Changelog** — Authoritative source for everything that ships
-  across GitHub and Copilot. [github.blog/changelog](https://github.blog/changelog/)
+- **Announcement (blog)** — GitHub Copilot is moving to usage-based billing. [github.blog](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/)
+- **Copilot Billing Preview Sidecar app (video)** — Walkthrough of the in-product billing preview. *Requires Microsoft 365 sign-in.* [SharePoint](https://microsoft.sharepoint.com/:v:/t/GithubSales/cQpdyZPg51mUQ7iLkqEsrO7pEgUCj1S9x-0AVt-DMqzr4c7NFw?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0=)
+- **UBB documentation** — Concept docs for usage-based billing in organizations and enterprises. [docs.github.com](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises)
+- **UBB pricing & models** — Reference for Copilot billing models and pricing. [docs.github.com](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing)
+- **GitHub Community FAQ** — Discussion thread with frequently asked questions. [github.com/orgs/community/discussions/192948](https://github.com/orgs/community/discussions/192948)
+- **Copilot code review changelog** — Code review will start consuming GitHub Actions minutes on June 1, 2026. [github.blog/changelog](https://github.blog/changelog/2026-04-27-github-copilot-code-review-will-start-consuming-github-actions-minutes-on-june-1-2026/)
 
 ---
 
 ## 🏛 Governance & Architecture
 
-For organizations adopting Copilot at scale — patterns, guardrails, and
-reference architectures.
-
-- **Agentic Governance (Microsoft APM)** — The Agentic Project Management
-  framework from Microsoft for governing teams of AI agents at enterprise
-  scale. [github.com/microsoft/apm](https://github.com/microsoft/apm)
-- **GitHub Well-Architected Framework** — GitHub's official guidance for
-  building well-architected systems on the GitHub platform, including
-  Copilot. [wellarchitected.github.com](https://wellarchitected.github.com/)
-
----
-
-## 🤝 CSI Resources
-
-A dedicated space for Copilot resources tailored to **CSI** (Canadian
-Strategic / large-account engagements). Content will be expanded in this
-section as it becomes available — start with the global resources above
-in the meantime.
+- **Agentic Governance (Microsoft APM)** — Microsoft's framework for governing teams of AI agents at enterprise scale. [docs](https://microsoft.github.io/apm/) · [repo](https://github.com/microsoft/apm)
+- **GitHub Well-Architected Framework** — GitHub's official guidance for well-architected systems on the GitHub platform, including Copilot. [wellarchitected.github.com](https://wellarchitected.github.com/)
 
 ---
 
 ## 💬 Get in Touch
 
-- **Open an issue** on this repository to suggest a resource, report a
-  broken link, or request that a new topic be covered. See the
-  [issue templates](.github/ISSUE_TEMPLATE) and [CONTRIBUTING.md](CONTRIBUTING.md).
-- **Through your Microsoft account team** — if you already work with a
-  Microsoft account team, they can route you to the GitHub Copilot Canada
-  team directly.
-- A direct engagement channel (email alias / Teams) for the GHCP Canada
-  team will be added here once finalized.
-
----
-
-## 🔒 Security, Trust & Compliance
-
-For information about reporting security vulnerabilities, see
-[SECURITY.md](SECURITY.md). For broader GitHub trust, security, and
-compliance documentation, visit
-[GitHub Trust Center](https://github.com/trust-center) and
-[GitHub Copilot Trust Center](https://resources.github.com/copilot-trust-center/).
+- **Email us** — [GitHubCopilotCanada@microsoft.com](mailto:GitHubCopilotCanada@microsoft.com)
+- **Open an issue** to suggest a resource, report a broken link, or request a topic — see [issue templates](.github/ISSUE_TEMPLATE) and [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Through your Microsoft account team** — they can route you to the GitHub Copilot Canada team directly.
 
 ---
 
 ## 🛠 Contributing
 
-Suggestions, broken-link reports, and improvements are welcome. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for how to propose a new resource or
-file a fix. By participating, you agree to abide by the
-[Microsoft Open Source Code of Conduct](CODE_OF_CONDUCT.md).
-
-For Microsoft employees: an internal companion site for GitHub Copilot
-Canada is coming soon and will be linked here once published.
-
----
-
-## Trademarks
-
-This project may contain trademarks or logos for projects, products, or
-services. Authorized use of Microsoft trademarks or logos is subject to
-and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project
-must not cause confusion or imply Microsoft sponsorship. Any use of
-third-party trademarks or logos is subject to those third parties' policies.
+Suggestions, broken-link reports, and improvements welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). By participating, you agree to the [Microsoft Open Source Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## 📅 Canada Events
 
 - **GHCP Dev Days Canada 🇨🇦** — Microsoft and GitHub's Canada-focused Copilot developer event series. [aka.ms/ghcp-dev-days-canada](https://aka.ms/ghcp-dev-days-canada)
-- **[AI Coding with GitHub Copilot — Development Enablement Series](https://proud-pebble-09ba52a0f.6.azurestaticapps.net/)** — Multi-part series for Canadian engineering teams covering prompt patterns, chat modes, agentic workflows, code review, and team-scale adoption.
+- **[AI Coding with GitHub Copilot — Development Enablement Series](https://aka.ms/ghcp-dev-enablement-series)** — Multi-part series for Canadian engineering teams covering prompt patterns, chat modes, agentic workflows, code review, and team-scale adoption.
 - **Apply for workshops, office hours & invite-only events** — Get on the GHCP Canada team's invite list. [aka.ms/ghcp-canada-events-form](https://aka.ms/ghcp-canada-events-form)
 
 


### PR DESCRIPTION
## Summary
 
 Rebalances `README.md` toward a tight landing-page feel — brevity + light visual structure — and adds new resources (Canada events form, APM docs link, 
contact email, Usage-Based Billing section, AI Coding series link, header banners).
 
 Net change: ~125 lines → ~78 lines, while adding 8 new public links.
 
 ## What changed
 
 ### Style / brevity
 - Header banner images added above the H1 (centered, side-by-side).
 - Multi-line prose intro replaced with a one-line blockquote tagline.
 - Persona table cells reduced to one short phrase + anchor link each.
 - Section intros dropped throughout; sub-headers under *Learning & Skilling* kept for visual rhythm.
 - *Developer Enablement* H2 merged into *Canada Events* (it was a duplicate bullet with no extra link).
 - *What's New* (single Changelog bullet) folded into *Learning & Skilling → Reference*.
 - Placeholder/coming-soon prose removed from *Canada Events*, *Get in Touch*, and *Contributing*.
 
 ### New resources
 - **Canada Events**: link to `aka.ms/ghcp-canada-events-form` (apply for workshops, office hours, invite-only events).
 - **Canada Events**: AI Coding / Development Enablement Series title hyperlinked to its registration site.
 - **Governance & Architecture**: APM bullet now links both **docs** (`microsoft.github.io/apm`) and **repo**.
 - **Get in Touch**: `GitHubCopilotCanada@microsoft.com` mailto link.
 - **NEW: 💳 Usage-Based Billing (UBB)** section with: announcement blog, Sidecar app SharePoint video (marked *Requires Microsoft 365 sign-in*), UBB 
concept docs, pricing & models reference, GitHub Community FAQ, Copilot code review Actions-minutes changelog.
 
 ## Things to flag for review
 
 1. **SharePoint video link in UBB section** — `CONTRIBUTING.md` excludes "Internal-only Microsoft material (links requiring corporate SSO, internal 
SharePoint, etc.)". Included with a clear sign-in marker because requested; reviewers may want to remove, replace with a public version, or move to the 
internal companion site.
 2. **Dev Enablement Series link** uses an Azure Static Web Apps preview hostname (`proud-pebble-09ba52a0f.6.azurestaticapps.net`). Worth swapping for a 
custom domain or `aka.ms/...` short link before this README circulates widely.
 3. **Bullet format consistency** — the AI Coding bullet uses *title-as-link* style; all other bullets follow `**Name** — description. [Link](url)` from 
`CONTRIBUTING.md`. Either restyle the one bullet or update guidance.