### PR TITLE
Reframe UBB resources section and add interactive tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 Resources about Copilot's move to usage-based billing.
 
-- **🇨🇦 Canada team recommendations** — A practical playbook for preparing your organization (what's changing June 1, a 5-step rollout plan, what not to overreact to, and resources to share with customers). [usage-based-billing/](./usage-based-billing/)
+- **🇨🇦 Canada team recommendations** — A practical playbook for preparing your organization (what's changing June 1, a 5-step rollout plan, what not to overreact to, and curated UBB resources including interactive tools and checklists). [usage-based-billing/](./usage-based-billing/)
 - **Announcement (blog)** — GitHub Copilot is moving to usage-based billing. [github.blog](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/)
 - **Copilot Billing Preview Sidecar app (video)** — Walkthrough of the in-product billing preview. *Requires Microsoft 365 sign-in.* [SharePoint](https://microsoft.sharepoint.com/:v:/t/GithubSales/cQpdyZPg51mUQ7iLkqEsrO7pEgUCj1S9x-0AVt-DMqzr4c7NFw?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0=)
 - **UBB documentation** — Concept docs for usage-based billing in organizations and enterprises. [docs.github.com](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises)

--- a/usage-based-billing/README.md
+++ b/usage-based-billing/README.md
@@ -97,13 +97,14 @@ selection.
 
 ---
 
-## 📦 Resources to Share with Customers
+## 📦 Usage-Based Billing Resources
 
-The **customer billing usage report is live as of May 12**. Share these
-resources with your customer when preparing them for UBB:
+The **customer billing usage report is live as of May 12**. The links
+below collect the most useful UBB references for admins and partners
+preparing their rollout:
 
 - **April reports are now available (changelog, May 12)** — Announces the
-  customer-facing billing usage report. Share with customers preparing for UBB.
+  customer-facing billing usage report.
   [github.blog/changelog](https://github.blog/changelog/2026-05-12-april-reports-are-now-available-to-prepare-for-usage-based-billing/)
 - **Preparing your organization for usage-based billing (docs)** — Step-by-step
   guidance for organization and enterprise admins.
@@ -113,6 +114,24 @@ resources with your customer when preparing them for UBB:
   [github.com/orgs/community/discussions/192948](https://github.com/orgs/community/discussions/192948)
 - **Webinar recap (on-demand video)** — Recap of the UBB customer briefing.
   [github.ondemand.goldcast.io](https://github.ondemand.goldcast.io/on-demand/9c23608e-dc81-41f3-82c2-6629c9a26f36)
+
+### Interactive tools & checklists
+
+> Community / partner-built tools — these are not official GitHub
+> documentation, but several teams have found them useful when explaining
+> UBB to admins and developers.
+
+- **UBB Resources (interactive tools)** — Animated explainer, 21 budget
+  flow scenarios, decision tree, budget calculator, and model-selection
+  playbook.
+  [white-cliff-095e8700f.7.azurestaticapps.net](https://white-cliff-095e8700f.7.azurestaticapps.net/index.html)
+- **Token-optimizer (interactive showcase)** — Scenarios, framework
+  diagram, pricing calculator, and model-selection playbook for token
+  optimization across AI coding workloads.
+  [ashy-dune-0b4215a0f.7.azurestaticapps.net](https://ashy-dune-0b4215a0f.7.azurestaticapps.net/detailed/index.html#/home)
+- **UBB Checklist (by Tim Corr)** — Step-by-step rollout checklist
+  grouped by timing and role, with local progress tracking.
+  [tjcorr.github.io/ubb-checklist](https://tjcorr.github.io/ubb-checklist/checklist.html)
 
 ### Webinars and workshops
 


### PR DESCRIPTION
## Summary

The section heading **"📦 Resources to Share with Customers"** in `usage-based-billing/README.md` reads awkwardly when the README itself is shared *with* customers — it talks *about* them in the third person. This PR reframes that section to address the reader directly and adds three interactive UBB resources we want partners and customers to know about.

## Changes

### `usage-based-billing/README.md`
- **Rename** `## 📦 Resources to Share with Customers` → `## 📦 Usage-Based Billing Resources`.
- **Rewrite** the intro paragraph so it addresses the reader directly (drops *"Share these resources with your customer when preparing them for UBB"*).
- **Trim** the redundant *"Share with customers preparing for UBB."* tail from the April-reports bullet.
- **Add** a new `### Interactive tools & checklists` subsection with a short *community / partner-built* disclaimer and three resources:
  - **UBB Resources (interactive tools)** — animated explainer, 21 budget flow scenarios, decision tree, budget calculator, and model-selection playbook. <https://white-cliff-095e8700f.7.azurestaticapps.net/index.html>
  - **Token-optimizer (interactive showcase)** — scenarios, framework diagram, pricing calculator, and model-selection playbook for token optimization across AI coding workloads. <https://ashy-dune-0b4215a0f.7.azurestaticapps.net/detailed/index.html#/home>
  - **UBB Checklist (by Tim Corr)** — step-by-step rollout checklist grouped by timing and role, with local progress tracking. <https://tjcorr.github.io/ubb-checklist/checklist.html>

### `README.md` (root)
- Update the Canada-team-recommendations bullet so the parenthetical ends with *"curated UBB resources including interactive tools and checklists"* instead of *"resources to share with customers"*, keeping it in sync with the renamed subsection.

## Notes

- The two Azure Static Web Apps URLs use auto-generated hostnames; we'll swap them for vanity domains in a follow-up if/when those land.
- The three new tools are flagged as *community / partner-built* in the README so customers understand they aren't official GitHub documentation.
- Verified: a grep for any *"share … customer(s)"* framing across both files returns zero hits after these edits.

Markdown-only; no build/test impact.