### PR TITLE
chore: omit registry URLs from npm lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -50,7 +49,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
@@ -60,7 +58,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
@@ -91,7 +88,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha1-zKC4gn5rzzuhdniOfzsYCtbbL6M=",
       "dev": true,
       "license": "MIT",
@@ -108,7 +104,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
@@ -125,7 +120,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
@@ -135,7 +129,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
@@ -149,7 +142,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
@@ -167,7 +159,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha1-wKB2bxoTYX2KF0B9erj51IYiXqQ=",
       "dev": true,
       "license": "MIT",
@@ -177,7 +168,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -187,7 +177,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -197,7 +186,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
@@ -207,7 +195,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
@@ -221,7 +208,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
       "dev": true,
       "license": "MIT",
@@ -237,7 +223,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
       "integrity": "sha1-wkQkUnhYIgYk/Vmlseq0+kE8gDo=",
       "dev": true,
       "license": "MIT",
@@ -253,7 +238,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
       "integrity": "sha1-XPJaNomQa1ji8KLys3R4nmYnsV8=",
       "dev": true,
       "license": "MIT",
@@ -269,7 +253,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha1-EgIkUMRaTabY2Ch7GKT/Ldsj92g=",
       "license": "MIT",
       "engines": {
@@ -278,7 +261,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
@@ -293,7 +275,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha1-xHsHpBuV2gkH0Ca13YlNmN59Ly0=",
       "dev": true,
       "license": "MIT",
@@ -312,7 +293,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
       "dev": true,
       "license": "MIT",
@@ -326,7 +306,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
       "integrity": "sha1-grdPkqp41yC3FBYpOfskjJCt31M=",
       "cpu": [
         "ppc64"
@@ -343,7 +322,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
       "integrity": "sha1-WT4QoUULv8rGyzIfYfRoRTusIJ0=",
       "cpu": [
         "arm"
@@ -360,7 +338,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
       "integrity": "sha1-94y4oxIfwgWlMoWtskly2zhdGF0=",
       "cpu": [
         "arm64"
@@ -377,7 +354,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
       "integrity": "sha1-RTFD0HMyYDPS0iyvnkjeS64nSwc=",
       "cpu": [
         "x64"
@@ -394,7 +370,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
       "integrity": "sha1-byMAD7m0C34Et9BgbAaTvQYy8yI=",
       "cpu": [
         "arm64"
@@ -411,7 +386,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
       "integrity": "sha1-Jzk90YuxJjxmOXnF8VduAMLQJL4=",
       "cpu": [
         "x64"
@@ -428,7 +402,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
       "integrity": "sha1-IuRjj6UC0cACcHcyTJdkDjrfOmI=",
       "cpu": [
         "arm64"
@@ -445,7 +418,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
       "integrity": "sha1-kiS45P6pJM4hlOPvw+muv4IhktY=",
       "cpu": [
         "x64"
@@ -462,7 +434,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
       "integrity": "sha1-uenQcMjBwESc8Ssg6sN9cKRZWSE=",
       "cpu": [
         "arm"
@@ -479,7 +450,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
       "integrity": "sha1-T10cJ1J9gXs1aEriFBnlfCvaCWY=",
       "cpu": [
         "arm64"
@@ -496,7 +466,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
       "integrity": "sha1-P4D7aWqpYFGpQEfzXIWwiyHDb54=",
       "cpu": [
         "ia32"
@@ -513,7 +482,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
       "integrity": "sha1-m+HywoIQsT67QVYiG7o1b+FnUgU=",
       "cpu": [
         "loong64"
@@ -530,7 +498,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
       "integrity": "sha1-SrXuZ6Pfy8tej9eIPa5uc1sRY7g=",
       "cpu": [
         "mips64el"
@@ -547,7 +514,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
       "integrity": "sha1-2seMaJ9kmUWcQyHlwVAywSMH5+o=",
       "cpu": [
         "ppc64"
@@ -564,7 +530,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
       "integrity": "sha1-BQ99OzVcOpgwjpNbxNYyXakbACc=",
       "cpu": [
         "riscv64"
@@ -581,7 +546,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
       "integrity": "sha1-1h9xXOYdQ/5YRK0Nj0Y/iMvk/vY=",
       "cpu": [
         "s390x"
@@ -598,7 +562,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
       "integrity": "sha1-yo4apHj8ggkle/Osj3nE3CmC8yo=",
       "cpu": [
         "x64"
@@ -615,7 +578,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
       "integrity": "sha1-FlDywblI3us++Ujy/DBhRyPAlpA=",
       "cpu": [
         "arm64"
@@ -632,7 +594,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
       "integrity": "sha1-ZXcqs0LEszGb8HBaIRBQqsG24yA=",
       "cpu": [
         "x64"
@@ -649,7 +610,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
       "integrity": "sha1-N+18+mZUnXlVhS/ON9DD3k5xXqE=",
       "cpu": [
         "arm64"
@@ -666,7 +626,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
       "integrity": "sha1-Ab89OFhV71DLM9t8S1L5V8NM0Xk=",
       "cpu": [
         "x64"
@@ -683,7 +642,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
       "integrity": "sha1-bB+Us0CGWZqr2k6sj2OClLmHdBA=",
       "cpu": [
         "arm64"
@@ -700,7 +658,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
       "integrity": "sha1-Sw3ReuCmlB0tD9NakGOSUXBxqQ0=",
       "cpu": [
         "x64"
@@ -717,7 +674,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
       "integrity": "sha1-NBk6tVZdb/aMqSisBL51ECzLLnc=",
       "cpu": [
         "arm64"
@@ -734,7 +690,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
       "integrity": "sha1-62fw5EglFdjBiU7eYxwyek2p/E0=",
       "cpu": [
         "ia32"
@@ -751,7 +706,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
       "integrity": "sha1-j+MLMIi4m0hzw6bMh1l645IMCos=",
       "cpu": [
         "x64"
@@ -768,19 +722,16 @@
     },
     "node_modules/@github/mini-throttle": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/mini-throttle/-/mini-throttle-2.1.1.tgz",
       "integrity": "sha1-xm21w7hXqvjEZ94lKM2S829UKsU=",
       "license": "MIT"
     },
     "node_modules/@github/relative-time-element": {
       "version": "5.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/relative-time-element/-/relative-time-element-5.3.0.tgz",
       "integrity": "sha1-5393RkzbYWg7AWpnoQkHu7W4Aao=",
       "license": "MIT"
     },
     "node_modules/@google/design.md": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@google/design.md/-/design.md-0.4.0.tgz",
       "integrity": "sha1-v9laTq1wTmLI43IhoEBlJwk2L/Q=",
       "dev": true,
       "dependencies": {
@@ -804,7 +755,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
@@ -815,7 +765,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
       "dev": true,
       "license": "MIT",
@@ -826,7 +775,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
@@ -836,14 +784,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
@@ -854,31 +800,26 @@
     },
     "node_modules/@lit-labs/react": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@lit-labs/react/-/react-1.2.1.tgz",
       "integrity": "sha1-W0IVAs32ijY53sQxMY7u0ihfHA4=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
       "integrity": "sha1-aT4Sm4CXQf0j6Y/LV+Qf09CC2xo=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@oddbird/popover-polyfill": {
       "version": "0.5.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oddbird/popover-polyfill/-/popover-polyfill-0.5.2.tgz",
       "integrity": "sha1-mhQsrlS25IgkvsYelOOVQcl0a2k=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@primer/behaviors": {
       "version": "1.10.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@primer/behaviors/-/behaviors-1.10.3.tgz",
       "integrity": "sha1-/TNGsj+14V5M5gWQs111CqrqYWg=",
       "license": "MIT"
     },
     "node_modules/@primer/css": {
       "version": "22.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@primer/css/-/css-22.3.0.tgz",
       "integrity": "sha1-BcUQadtU8i0I3yLvj3x9BxUu8Vo=",
       "license": "MIT",
       "engines": {
@@ -890,7 +831,6 @@
     },
     "node_modules/@primer/live-region-element": {
       "version": "0.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@primer/live-region-element/-/live-region-element-0.8.0.tgz",
       "integrity": "sha1-efilgkp3YtJuuGeJli3lTlwpXe4=",
       "license": "MIT",
       "dependencies": {
@@ -899,7 +839,6 @@
     },
     "node_modules/@primer/octicons-react": {
       "version": "19.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@primer/octicons-react/-/octicons-react-19.32.0.tgz",
       "integrity": "sha1-iddh85oLQqLRHnW87IFCXnGo360=",
       "license": "MIT",
       "engines": {
@@ -911,13 +850,11 @@
     },
     "node_modules/@primer/primitives": {
       "version": "10.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@primer/primitives/-/primitives-10.7.0.tgz",
       "integrity": "sha1-drGM8CCwoyRqn0mKuWQbZeM+EN4=",
       "license": "MIT"
     },
     "node_modules/@primer/react": {
       "version": "38.34.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@primer/react/-/react-38.34.0.tgz",
       "integrity": "sha1-8Qve22MWj585LzCNgKu4Zyiw/oM=",
       "license": "MIT",
       "dependencies": {
@@ -967,14 +904,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
       "integrity": "sha1-iojMkqD3Qb78e8EJyxpMa5QI4cU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
       "integrity": "sha1-sKtCL7YPNYPIx4noVtZKMlB/KZ4=",
       "cpu": [
         "arm"
@@ -988,7 +923,6 @@
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
       "integrity": "sha1-BH6WfutECimfGrx3NXm1wlFvpI0=",
       "cpu": [
         "arm64"
@@ -1002,7 +936,6 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
       "integrity": "sha1-GDaeZ9DT/8sBqVVhIXRHt5Fydpc=",
       "cpu": [
         "arm64"
@@ -1016,7 +949,6 @@
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
       "integrity": "sha1-vyOuTFwPhBsSO8eeOyRhdsbQj9c=",
       "cpu": [
         "x64"
@@ -1030,7 +962,6 @@
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
       "integrity": "sha1-ySobB9AkMYHybZ3rJ4w+8J4B8GU=",
       "cpu": [
         "arm64"
@@ -1044,7 +975,6 @@
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
       "integrity": "sha1-tp2gQH6gZJfTlb4OeZzGAQBLNy4=",
       "cpu": [
         "x64"
@@ -1058,7 +988,6 @@
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
       "integrity": "sha1-G0tjxX/CDm6kdIqOqGTYZRMyjsQ=",
       "cpu": [
         "arm"
@@ -1075,7 +1004,6 @@
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
       "integrity": "sha1-ZDNPWlF4yrsV59KpH7WS2x+GIdM=",
       "cpu": [
         "arm"
@@ -1092,7 +1020,6 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
       "integrity": "sha1-H/KZ94JfD1Ko4Qfax/Fc5zAJhIs=",
       "cpu": [
         "arm64"
@@ -1109,7 +1036,6 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
       "integrity": "sha1-mQUjgOepT6RAuRZsZ6kJqjVy8Ik=",
       "cpu": [
         "arm64"
@@ -1126,7 +1052,6 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
       "integrity": "sha1-X1i1drNmjt9irPDFJlgmJnt9hY8=",
       "cpu": [
         "loong64"
@@ -1143,7 +1068,6 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
       "integrity": "sha1-qM0DN+P/OgyV6tZ3FcUa93xa/zY=",
       "cpu": [
         "loong64"
@@ -1160,7 +1084,6 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
       "integrity": "sha1-YzXOwVtVprBj40y36WhRX6UA/9Q=",
       "cpu": [
         "ppc64"
@@ -1177,7 +1100,6 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
       "integrity": "sha1-zytv0jjwkoxWV7uKXKd1HfwubOQ=",
       "cpu": [
         "ppc64"
@@ -1194,7 +1116,6 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
       "integrity": "sha1-35UIyHIUN/flGZDKqmHS8423PL8=",
       "cpu": [
         "riscv64"
@@ -1211,7 +1132,6 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
       "integrity": "sha1-DP6TBy9MOYu51mbllTNxoiq6f0o=",
       "cpu": [
         "riscv64"
@@ -1228,7 +1148,6 @@
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
       "integrity": "sha1-+Oe989QZhmtoiwnZNIJTklIy0cs=",
       "cpu": [
         "s390x"
@@ -1245,7 +1164,6 @@
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
       "integrity": "sha1-V+9/A5xPfeDpE/HyaAOFRnuGuxU=",
       "cpu": [
         "x64"
@@ -1262,7 +1180,6 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
       "integrity": "sha1-b1tWk9S+sVK/UYxIfSWTYtvs5Ek=",
       "cpu": [
         "x64"
@@ -1279,7 +1196,6 @@
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
       "integrity": "sha1-mQkBAJPtf7JIDHO8GTqPTUT/ueM=",
       "cpu": [
         "x64"
@@ -1293,7 +1209,6 @@
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
       "integrity": "sha1-q6kLV3Jfz0xAcslabb+891AKdw0=",
       "cpu": [
         "arm64"
@@ -1307,7 +1222,6 @@
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
       "integrity": "sha1-Es7isubTfbuDYCaGgS5LuikMmqM=",
       "cpu": [
         "arm64"
@@ -1321,7 +1235,6 @@
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
       "integrity": "sha1-ORoNb4RYpnWtcgzMrpvLmkgQkBY=",
       "cpu": [
         "ia32"
@@ -1335,7 +1248,6 @@
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
       "integrity": "sha1-Pzi7GA/PHPqRl1xLNElB6YWm7RM=",
       "cpu": [
         "x64"
@@ -1349,7 +1261,6 @@
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
       "integrity": "sha1-DMr9RKjLyzP3/qqePoUDPnpSKVw=",
       "cpu": [
         "x64"
@@ -1363,7 +1274,6 @@
     },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.14.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
       "integrity": "sha1-tzXpOgWaJfV3qVd9fwFDQ+xyBaU=",
       "license": "MIT",
       "dependencies": {
@@ -1380,7 +1290,6 @@
     },
     "node_modules/@tanstack/virtual-core": {
       "version": "3.17.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
       "integrity": "sha1-1kUl0sl6U6IvMvVSRu/dZ5ryw5I=",
       "license": "MIT",
       "funding": {
@@ -1390,7 +1299,6 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
       "dev": true,
       "license": "MIT",
@@ -1404,7 +1312,6 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha1-tYGSlMUReZV6+uw0FEL5NB5BCKk=",
       "dev": true,
       "license": "MIT",
@@ -1414,7 +1321,6 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
       "dev": true,
       "license": "MIT",
@@ -1425,7 +1331,6 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha1-B9cT1szg0mXJhJ2wy+YtP2Hzb3Q=",
       "dev": true,
       "license": "MIT",
@@ -1435,7 +1340,6 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha1-ItHMnVQtNZPK6nZPl0MGqzYobuc=",
       "license": "MIT",
       "dependencies": {
@@ -1444,13 +1348,11 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
       "integrity": "sha1-hYqI6iDzT+ZREfAFpon6Hr9w3Bg=",
       "license": "MIT",
       "dependencies": {
@@ -1459,7 +1361,6 @@
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/hast/-/hast-3.0.5.tgz",
       "integrity": "sha1-SAIN5MDmNJL0yp20IGjBCPaLf48=",
       "license": "MIT",
       "dependencies": {
@@ -1468,7 +1369,6 @@
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha1-fM9y7dLxqn3TQ34YDGQ3NYWATdY=",
       "license": "MIT",
       "dependencies": {
@@ -1477,13 +1377,11 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha1-kekhgsk9uL1iJPygMeI3DO+ajwE=",
       "dev": true,
       "license": "MIT",
@@ -1493,7 +1391,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha1-OWBJKbXjlX46b6AAHa+xfHr3C60=",
       "license": "MIT",
       "dependencies": {
@@ -1502,7 +1399,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha1-weMF0VpSo+UI1U3Kdw0gLLY6vyw=",
       "devOptional": true,
       "license": "MIT",
@@ -1512,7 +1408,6 @@
     },
     "node_modules/@types/react-is": {
       "version": "19.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-is/-/react-is-19.2.0.tgz",
       "integrity": "sha1-tyoBYn5IIPIzOr3JlFw9qsSCRec=",
       "devOptional": true,
       "license": "MIT",
@@ -1522,19 +1417,16 @@
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha1-rKqw+RnOaczmKcLU7S60rcG2wgw=",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha1-CUBB4aTLGYfwODNUISgayL45C8w=",
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
       "integrity": "sha1-W0d+Bgv2Eqc5TE/rrMXeM6IZsOQ=",
       "dev": true,
       "license": "MIT",
@@ -1555,7 +1447,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1568,7 +1459,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1578,7 +1468,6 @@
     },
     "node_modules/bail": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bail/-/bail-2.0.2.tgz",
       "integrity": "sha1-0m9c2P5db4MqMVF7n3w1YEC6bV0=",
       "license": "MIT",
       "funding": {
@@ -1588,7 +1477,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
       "integrity": "sha1-Qutf/Jn9icqL8w4xVXtIcGPuyG8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1601,7 +1489,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
       "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
       "dev": true,
       "funding": [
@@ -1635,7 +1522,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
       "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
@@ -1656,7 +1542,6 @@
     },
     "node_modules/ccount": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha1-F6O/gjAuCHDW2kOgExGovAKj7PU=",
       "license": "MIT",
       "funding": {
@@ -1666,7 +1551,6 @@
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha1-LQnC5yzZUjB2zLIRV9/2atQ/zCI=",
       "license": "MIT",
       "funding": {
@@ -1676,7 +1560,6 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha1-HxrblAyXGksiujndymthjcblays=",
       "license": "MIT",
       "funding": {
@@ -1686,7 +1569,6 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha1-dryDqQc4kB17wiOp6TdZ/dVgEls=",
       "license": "MIT",
       "funding": {
@@ -1696,7 +1578,6 @@
     },
     "node_modules/character-reference-invalid": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha1-hcZrBB5DtHIQ+vQBJ4q/gIrEXLk=",
       "license": "MIT",
       "funding": {
@@ -1706,7 +1587,6 @@
     },
     "node_modules/citty": {
       "version": "0.1.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/citty/-/citty-0.1.6.tgz",
       "integrity": "sha1-D3kE2h7UYl4anqfg+ngJgaq3xeQ=",
       "dev": true,
       "license": "MIT",
@@ -1716,7 +1596,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
       "license": "MIT",
       "engines": {
@@ -1725,13 +1604,11 @@
     },
     "node_modules/color2k": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color2k/-/color2k-2.0.4.tgz",
       "integrity": "sha1-yHTaHm8In8wy71qwQn57p/4GnWQ=",
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha1-TonJRYrLYbyP7xn0UplzsjkoOe4=",
       "license": "MIT",
       "funding": {
@@ -1741,7 +1618,6 @@
     },
     "node_modules/consola": {
       "version": "3.4.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/consola/-/consola-3.4.2.tgz",
       "integrity": "sha1-WvEQFFOXu2ev2rdwE/3DTK5ZDqc=",
       "dev": true,
       "license": "MIT",
@@ -1751,20 +1627,17 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
@@ -1781,7 +1654,6 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha1-PkBgN2CHTC5YZ2kbWZ1zp9oltT8=",
       "license": "MIT",
       "dependencies": {
@@ -1794,7 +1666,6 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha1-RLXyFHzTsA1LVhN2hZZvJv0l3Uo=",
       "license": "MIT",
       "engines": {
@@ -1803,7 +1674,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
       "license": "MIT",
       "engines": {
@@ -1812,7 +1682,6 @@
     },
     "node_modules/devlop": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha1-TbfCyk3G4Og0wwvnDJS7yXbccBg=",
       "license": "MIT",
       "dependencies": {
@@ -1825,14 +1694,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.398",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
       "integrity": "sha1-nU2Xk0SsdihAKT4+rL6+00IoqhY=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-6.0.1.tgz",
       "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
       "license": "BSD-2-Clause",
       "engines": {
@@ -1844,7 +1711,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha1-vK3OIrLz/XbyV+OmT4OmSYb+oR8=",
       "dev": true,
       "hasInstallScript": true,
@@ -1886,7 +1752,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -1896,7 +1761,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha1-RoMSa1ALYXYvLb66zhgG6L4xscg=",
       "license": "MIT",
       "engines": {
@@ -1908,7 +1772,6 @@
     },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
       "integrity": "sha1-C170xP8TUIs03NAez6lF9h/OXb0=",
       "license": "MIT",
       "funding": {
@@ -1918,7 +1781,6 @@
     },
     "node_modules/estree-util-visit": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
       "integrity": "sha1-E6mp9A/1DtDAIvgx3fS1jQVEb+s=",
       "dev": true,
       "license": "MIT",
@@ -1933,13 +1795,11 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "license": "MIT"
     },
     "node_modules/fault": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fault/-/fault-2.0.1.tgz",
       "integrity": "sha1-1Hyp83yibkvTg3SnxQC1o4R1W2w=",
       "dev": true,
       "license": "MIT",
@@ -1953,7 +1813,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -1971,13 +1830,11 @@
     },
     "node_modules/focus-visible": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/focus-visible/-/focus-visible-5.2.1.tgz",
       "integrity": "sha1-OGFei+TU33gZoNnZLN7k/aGDrJY=",
       "license": "W3C"
     },
     "node_modules/format": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true,
       "engines": {
@@ -1986,7 +1843,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
       "license": "MIT",
@@ -2000,7 +1856,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "license": "MIT",
@@ -2010,13 +1865,11 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha1-Us8vknmiHrbFndOFtBDwwK3ajxo=",
       "license": "ISC"
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
       "integrity": "sha1-gwo1Ai//KMP+o2l6mML0zGuDWi4=",
       "license": "MIT",
       "dependencies": {
@@ -2036,7 +1889,6 @@
     },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
       "integrity": "sha1-LVxvKAenr1xF905iNJjdYFTSq6g=",
       "license": "MIT",
       "dependencies": {
@@ -2049,7 +1901,6 @@
     },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha1-NSh5+obiVhYDYDfdiTH7XzTLSic=",
       "license": "MIT",
       "dependencies": {
@@ -2062,7 +1913,6 @@
     },
     "node_modules/hast-util-raw": {
       "version": "9.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
       "integrity": "sha1-ebZrJvb2j7UN+0cWss3KkNkq3y4=",
       "license": "MIT",
       "dependencies": {
@@ -2087,7 +1937,6 @@
     },
     "node_modules/hast-util-sanitize": {
       "version": "5.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
       "integrity": "sha1-7bJg2U5buiAw65N1eQqHU+W/OR8=",
       "license": "MIT",
       "dependencies": {
@@ -2102,7 +1951,6 @@
     },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
       "integrity": "sha1-/zGJeq5Z9iIy4hWU6sfva2MzPpg=",
       "license": "MIT",
       "dependencies": {
@@ -2129,7 +1977,6 @@
     },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
       "integrity": "sha1-lao5HMBRS0lRQY0ByIPRA4r0L10=",
       "license": "MIT",
       "dependencies": {
@@ -2148,7 +1995,6 @@
     },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
       "integrity": "sha1-pPFeaChJMm3SEclxKclLDD52Unw=",
       "license": "MIT",
       "dependencies": {
@@ -2161,7 +2007,6 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha1-d3jtnTyS3Z6MXI9kiknCH8UctiE=",
       "license": "MIT",
       "dependencies": {
@@ -2174,7 +2019,6 @@
     },
     "node_modules/hastscript": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hastscript/-/hastscript-9.0.1.tgz",
       "integrity": "sha1-28hL72BR1ACENCwinEUc2dxWff8=",
       "license": "MIT",
       "dependencies": {
@@ -2191,7 +2035,6 @@
     },
     "node_modules/history": {
       "version": "5.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/history/-/history-5.3.0.tgz",
       "integrity": "sha1-FUirqiRbpHmS8GOgeD25HvIBxzs=",
       "license": "MIT",
       "dependencies": {
@@ -2200,13 +2043,11 @@
     },
     "node_modules/hsluv": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hsluv/-/hsluv-1.0.1.tgz",
       "integrity": "sha1-j5V6/T+SjS3n91adt2h/gRuyuu0=",
       "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
       "integrity": "sha1-g7BSzV5DcHG3Vs10rnD3CIcMLYc=",
       "license": "MIT",
       "funding": {
@@ -2216,7 +2057,6 @@
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha1-/J29hK+edHJJA01NYmAt72UX8dc=",
       "license": "MIT",
       "funding": {
@@ -2226,13 +2066,11 @@
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha1-sfxov8AxO4aFdF5EZON/k3a5yQk=",
       "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha1-AQcgU+p8EDbfPH0Zptqux/GeeJs=",
       "license": "MIT",
       "funding": {
@@ -2242,7 +2080,6 @@
     },
     "node_modules/is-alphanumerical": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha1-fAP76W4+kxET5X+WSwo2jMLf2HU=",
       "license": "MIT",
       "dependencies": {
@@ -2256,7 +2093,6 @@
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha1-lGnS3BkNAhT9h9eLeMrswMwU7vc=",
       "license": "MIT",
       "funding": {
@@ -2266,7 +2102,6 @@
     },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha1-hrW/Zo/KMHSY0xnfwDKJ14GpACc=",
       "license": "MIT",
       "funding": {
@@ -2276,7 +2111,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha1-1lAl7ew2V84DL9fbY8l4g+rtcfA=",
       "license": "MIT",
       "engines": {
@@ -2288,14 +2122,12 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
@@ -2308,7 +2140,6 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
@@ -2321,19 +2152,16 @@
     },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
       "license": "MIT"
     },
     "node_modules/lodash.isobject": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha1-YvpnzZWHQqFXSvnzmGY2QQLZDNQ=",
       "license": "MIT",
       "funding": {
@@ -2343,7 +2171,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
@@ -2353,7 +2180,6 @@
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha1-/kTW1BD/nW8uoXl6P2CqTStjHCo=",
       "license": "MIT",
       "funding": {
@@ -2363,7 +2189,6 @@
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha1-cKMXTIlOFN9yKr9DvCUMuuRLEd8=",
       "license": "MIT",
       "dependencies": {
@@ -2379,7 +2204,6 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha1-yVgiuRqrdfGKTL6LL1G4c+0s8Mc=",
       "license": "MIT",
       "dependencies": {
@@ -2403,7 +2227,6 @@
     },
     "node_modules/mdast-util-frontmatter": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
       "integrity": "sha1-9fkp6x6zbIp3N0dcfrQ4Jh+WTug=",
       "dev": true,
       "license": "MIT",
@@ -2422,7 +2245,6 @@
     },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha1-LN9juSwqMxQGsPsNtMB3wbAzF1E=",
       "license": "MIT",
       "dependencies": {
@@ -2441,7 +2263,6 @@
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha1-q9VXYwM3vTCm1aS9glLhwtwIddU=",
       "license": "MIT",
       "dependencies": {
@@ -2458,7 +2279,6 @@
     },
     "node_modules/mdast-util-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha1-d3jp2co99yOMwr0/orG/amWxlAM=",
       "license": "MIT",
       "dependencies": {
@@ -2475,7 +2295,6 @@
     },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha1-1E756O0oOsjBFlqw0N/QWMJ2TBY=",
       "license": "MIT",
       "dependencies": {
@@ -2490,7 +2309,6 @@
     },
     "node_modules/mdast-util-gfm-table": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha1-ekNftiI6crCGKzOvvXErba6HjTg=",
       "license": "MIT",
       "dependencies": {
@@ -2507,7 +2325,6 @@
     },
     "node_modules/mdast-util-gfm-task-list-item": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha1-5oCV0vikMD7yQJSrZC4QR7mRqTY=",
       "license": "MIT",
       "dependencies": {
@@ -2523,7 +2340,6 @@
     },
     "node_modules/mdast-util-mdx": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
       "integrity": "sha1-eS+c8DYbRr7h/fHvNr6sQkoJnEE=",
       "dev": true,
       "license": "MIT",
@@ -2541,7 +2357,6 @@
     },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
       "integrity": "sha1-Q/CrrJrcdW4ghvY4IqOMjTw6UJY=",
       "license": "MIT",
       "dependencies": {
@@ -2559,7 +2374,6 @@
     },
     "node_modules/mdast-util-mdx-jsx": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
       "integrity": "sha1-/QTGeip0me+5BailxXjd3J/a2g0=",
       "license": "MIT",
       "dependencies": {
@@ -2583,7 +2397,6 @@
     },
     "node_modules/mdast-util-mdxjs-esm": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
       "integrity": "sha1-AZz751etYt1VfbNaaV5zFLzJ+pc=",
       "license": "MIT",
       "dependencies": {
@@ -2601,7 +2414,6 @@
     },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha1-fMCo3sMOrwS3salmGpKtszgqpuM=",
       "license": "MIT",
       "dependencies": {
@@ -2615,7 +2427,6 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha1-1/+EykmaV+LAYK5nVIrZUOaJoFM=",
       "license": "MIT",
       "dependencies": {
@@ -2636,7 +2447,6 @@
     },
     "node_modules/mdast-util-to-markdown": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha1-+RD/5giX8Eu0t+fuQ0SG92KINhs=",
       "license": "MIT",
       "dependencies": {
@@ -2657,7 +2467,6 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha1-elEhR1VWoE5+3etnsmSq550xKBQ=",
       "license": "MIT",
       "dependencies": {
@@ -2670,7 +2479,6 @@
     },
     "node_modules/micromark": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha1-kTlaPhiEoZjmIRbjPJxWjjmTb9s=",
       "funding": [
         {
@@ -2705,7 +2513,6 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha1-xpFjDkhQIaaM8o28Kyyifr9njNQ=",
       "funding": [
         {
@@ -2739,7 +2546,6 @@
     },
     "node_modules/micromark-extension-frontmatter": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
       "integrity": "sha1-ZRxS/6XXqO7taHxRPNhpiFiC1no=",
       "dev": true,
       "license": "MIT",
@@ -2756,7 +2562,6 @@
     },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha1-PhM3arld16XP0OKVYN/pmWV7PFs=",
       "license": "MIT",
       "dependencies": {
@@ -2776,7 +2581,6 @@
     },
     "node_modules/micromark-extension-gfm-autolink-literal": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha1-Yoau6WhsRGLB41UqnVBf7dzuuTU=",
       "license": "MIT",
       "dependencies": {
@@ -2792,7 +2596,6 @@
     },
     "node_modules/micromark-extension-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha1-TatW1OOYuYU/b+TvrE/JNh8+B1A=",
       "license": "MIT",
       "dependencies": {
@@ -2812,7 +2615,6 @@
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha1-hhBt+LOmkrX2qSKA04eb5r5G2SM=",
       "license": "MIT",
       "dependencies": {
@@ -2830,7 +2632,6 @@
     },
     "node_modules/micromark-extension-gfm-table": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha1-+scLy/Uf5l9fRAMxGNOb6Km1lAs=",
       "license": "MIT",
       "dependencies": {
@@ -2847,7 +2648,6 @@
     },
     "node_modules/micromark-extension-gfm-tagfilter": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha1-8m2KeAe1mF+6E89hRltYyl/33Fc=",
       "license": "MIT",
       "dependencies": {
@@ -2860,7 +2660,6 @@
     },
     "node_modules/micromark-extension-gfm-task-list-item": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha1-vMNNgFY5gpmQ7BdcPuoSu1t4Hyw=",
       "license": "MIT",
       "dependencies": {
@@ -2877,7 +2676,6 @@
     },
     "node_modules/micromark-extension-mdx-expression": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
       "integrity": "sha1-Q9BY2ZlTL7MEEZWjw8BcRvqEVDs=",
       "dev": true,
       "funding": [
@@ -2904,7 +2702,6 @@
     },
     "node_modules/micromark-extension-mdx-jsx": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
       "integrity": "sha1-/8mL22SXmJAvqfxWifZ/nByQIEQ=",
       "dev": true,
       "license": "MIT",
@@ -2927,7 +2724,6 @@
     },
     "node_modules/micromark-extension-mdx-md": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
       "integrity": "sha1-HSUogeo110aYQjq0SRfh9bGXuS0=",
       "dev": true,
       "license": "MIT",
@@ -2941,7 +2737,6 @@
     },
     "node_modules/micromark-extension-mdxjs": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
       "integrity": "sha1-taLg7USSiPP29sVENYFZVXVJ3hg=",
       "dev": true,
       "license": "MIT",
@@ -2962,7 +2757,6 @@
     },
     "node_modules/micromark-extension-mdxjs-esm": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
       "integrity": "sha1-3iGysEX9IFm9ANNnRggd44OQ1Uo=",
       "dev": true,
       "license": "MIT",
@@ -2984,7 +2778,6 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha1-j++OD3CB8EdPvdkt61DJkKAmRjk=",
       "funding": [
         {
@@ -3005,7 +2798,6 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha1-UmfvqX8eUlTvx/ILRZo4yyEFi6E=",
       "funding": [
         {
@@ -3027,7 +2819,6 @@
     },
     "node_modules/micromark-factory-mdx-expression": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
       "integrity": "sha1-uwmYhhBYnAfRweRCUoWJUEGz36k=",
       "dev": true,
       "funding": [
@@ -3055,7 +2846,6 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha1-NtAhLpYrKzEh+FJfx6PHwCnzNPw=",
       "funding": [
         {
@@ -3075,7 +2865,6 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha1-I35KpdWKlYY/AQMtnumwkPHebpQ=",
       "funding": [
         {
@@ -3097,7 +2886,6 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha1-BrJrKYPE0nv8xlezPiUTTUhosLE=",
       "funding": [
         {
@@ -3119,7 +2907,6 @@
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha1-L5h4MaQNTFEKwmHomFLE6XA8zaY=",
       "funding": [
         {
@@ -3139,7 +2926,6 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha1-R/vNk0caP8yrhs/wOEf8NVLbEFE=",
       "funding": [
         {
@@ -3158,7 +2944,6 @@
     },
     "node_modules/micromark-util-classify-character": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha1-05n6+cRcoUyLS+mLHqSBvO2Htik=",
       "funding": [
         {
@@ -3179,7 +2964,6 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha1-Kg9JCrCL/1zC/V7sbdDKBPibMKk=",
       "funding": [
         {
@@ -3199,7 +2983,6 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha1-/PFbZgl5OI5vEYzba/fXnXPSb+U=",
       "funding": [
         {
@@ -3218,7 +3001,6 @@
     },
     "node_modules/micromark-util-decode-string": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha1-bLmVguXScehO/KjmGoB5lNcWHrI=",
       "funding": [
         {
@@ -3240,7 +3022,6 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha1-DVHRwJVVHPqsNoMmljz1XxX1QLg=",
       "funding": [
         {
@@ -3256,7 +3037,6 @@
     },
     "node_modules/micromark-util-events-to-acorn": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
       "integrity": "sha1-56imtVpH5aBscg1aHEq66MN8mPM=",
       "dev": true,
       "funding": [
@@ -3282,7 +3062,6 @@
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha1-5AQDCWSBmGtBwQZif5j3LU0QuCU=",
       "funding": [
         {
@@ -3298,7 +3077,6 @@
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha1-ww13sugyrPZSb4vxqke8nJQ4wW0=",
       "funding": [
         {
@@ -3317,7 +3095,6 @@
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha1-4aLWLN0jcjCirhGDkCexk4HjHos=",
       "funding": [
         {
@@ -3336,7 +3113,6 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha1-q4l4m4GKWHUrc9a1UjhiG3+qj9c=",
       "funding": [
         {
@@ -3357,7 +3133,6 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha1-2K3lug8xl6HPaimZ+7/mNXoaGe4=",
       "funding": [
         {
@@ -3379,7 +3154,6 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha1-5dpJTo6ysHGg0I+zT2zv7GwKGbg=",
       "funding": [
         {
@@ -3395,7 +3169,6 @@
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha1-8AIl9fWg68MlT5bDa2YFxLOTkI4=",
       "funding": [
         {
@@ -3411,13 +3184,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -3436,7 +3207,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
       "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
@@ -3446,7 +3216,6 @@
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha1-YdRvXtKOTuYundxD1rAQGIRD8Vk=",
       "license": "MIT",
       "dependencies": {
@@ -3465,13 +3234,11 @@
     },
     "node_modules/parse-entities/node_modules/@types/unist": {
       "version": "2.0.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha1-Ea9XsSfjJId3SEH3pOVOqxZtA8Q=",
       "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha1-1+Ik+nI5nHoXUJn0X8KtAksF7AU=",
       "license": "MIT",
       "dependencies": {
@@ -3483,14 +3250,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
@@ -3503,7 +3268,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.25",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=",
       "dev": true,
       "funding": [
@@ -3532,7 +3296,6 @@
     },
     "node_modules/property-information": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/property-information/-/property-information-7.2.0.tgz",
       "integrity": "sha1-CAmzQmTplcC/zTInAooeNSEK+Ao=",
       "license": "MIT",
       "funding": {
@@ -3542,7 +3305,6 @@
     },
     "node_modules/react": {
       "version": "19.2.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react/-/react-19.2.8.tgz",
       "integrity": "sha1-qAZj27WNacb+P9KR08syTop9/y0=",
       "license": "MIT",
       "engines": {
@@ -3551,7 +3313,6 @@
     },
     "node_modules/react-compiler-runtime": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-compiler-runtime/-/react-compiler-runtime-1.0.0.tgz",
       "integrity": "sha1-7lZcLNNDekHn/DHYq2xmL2tWj8A=",
       "license": "MIT",
       "peerDependencies": {
@@ -3560,7 +3321,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha1-O0a57tqHfN/yzxPSdw//SuNsLsI=",
       "license": "MIT",
       "dependencies": {
@@ -3572,7 +3332,6 @@
     },
     "node_modules/react-intersection-observer": {
       "version": "10.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-intersection-observer/-/react-intersection-observer-10.1.0.tgz",
       "integrity": "sha1-Su30GMeT8rzyc1MmP0NVPRKvunE=",
       "license": "MIT",
       "peerDependencies": {
@@ -3587,13 +3346,11 @@
     },
     "node_modules/react-is": {
       "version": "19.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-19.2.0.tgz",
       "integrity": "sha1-3cO0pODzM2w4R/GLgGUGOI17mXM=",
       "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-markdown/-/react-markdown-10.1.0.tgz",
       "integrity": "sha1-4ivCD63bwHYFwVKEJVZTwPO61co=",
       "license": "MIT",
       "dependencies": {
@@ -3620,7 +3377,6 @@
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha1-Lc6X9P6TKk2BQvoWMOR1wXKcgGI=",
       "dev": true,
       "license": "MIT",
@@ -3630,7 +3386,6 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-raw/-/rehype-raw-7.0.0.tgz",
       "integrity": "sha1-Wdc0j9Xb7zgHu6odRD79LdhezuQ=",
       "license": "MIT",
       "dependencies": {
@@ -3645,7 +3400,6 @@
     },
     "node_modules/rehype-sanitize": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
       "integrity": "sha1-FulfSmemnL8PeeETyODfSCA9tzw=",
       "license": "MIT",
       "dependencies": {
@@ -3659,7 +3413,6 @@
     },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-slug/-/rehype-slug-6.0.0.tgz",
       "integrity": "sha1-HSHPf8ioPvh02HPBXmra7mNE6vE=",
       "license": "MIT",
       "dependencies": {
@@ -3676,7 +3429,6 @@
     },
     "node_modules/remark-frontmatter": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
       "integrity": "sha1-to1hVSpCHsQSx29PZsNEYn3Bh6I=",
       "dev": true,
       "license": "MIT",
@@ -3693,7 +3445,6 @@
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha1-MyJ7KnQ5dnDTV78FwJjq+FE/DWs=",
       "license": "MIT",
       "dependencies": {
@@ -3711,7 +3462,6 @@
     },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-mdx/-/remark-mdx-3.1.1.tgz",
       "integrity": "sha1-BH+XA4vH7Dh667SwpP4jd5mZ2EU=",
       "dev": true,
       "license": "MIT",
@@ -3726,7 +3476,6 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha1-qmB0P8s36/awaSBOtNowTkDbRaE=",
       "license": "MIT",
       "dependencies": {
@@ -3742,7 +3491,6 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-rehype/-/remark-rehype-11.1.2.tgz",
       "integrity": "sha1-Kt2q3agMqb2aoNp2PnTRYydoOzc=",
       "license": "MIT",
       "dependencies": {
@@ -3759,7 +3507,6 @@
     },
     "node_modules/remark-stringify": {
       "version": "11.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha1-TFsB3XEcJp3xqq4RdD634udjb9M=",
       "license": "MIT",
       "dependencies": {
@@ -3774,7 +3521,6 @@
     },
     "node_modules/rollup": {
       "version": "4.62.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rollup/-/rollup-4.62.3.tgz",
       "integrity": "sha1-A+6Z4rWwdE3Zm+bUI4svzUCHtPY=",
       "dev": true,
       "license": "MIT",
@@ -3819,13 +3565,11 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha1-DE74LWfR5cHjWej8dtOofwRf5b0=",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -3835,7 +3579,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3845,7 +3588,6 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha1-Hs2dI1CjhEVyw/SjErzrAYNIhZ8=",
       "license": "MIT",
       "funding": {
@@ -3855,7 +3597,6 @@
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha1-s7ee9fJ3zErHPK6wI2xbqTmzpPM=",
       "license": "MIT",
       "dependencies": {
@@ -3869,7 +3610,6 @@
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/style-to-js/-/style-to-js-1.1.21.tgz",
       "integrity": "sha1-KQiUEYf4V+eeKOnNeACLmgs+Do0=",
       "license": "MIT",
       "dependencies": {
@@ -3878,7 +3618,6 @@
     },
     "node_modules/style-to-object": {
       "version": "1.0.14",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/style-to-object/-/style-to-object-1.0.14.tgz",
       "integrity": "sha1-HSLw5yZruMbYyuXK9OxPAF4I9hE=",
       "license": "MIT",
       "dependencies": {
@@ -3887,7 +3626,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -3904,7 +3642,6 @@
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha1-2ALjMqB9+GHEiALAQyEBexvYczg=",
       "license": "MIT",
       "funding": {
@@ -3914,7 +3651,6 @@
     },
     "node_modules/trough": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/trough/-/trough-2.2.0.tgz",
       "integrity": "sha1-lKYL1r03XBUsHfkRpLEdWwJW9Q8=",
       "license": "MIT",
       "funding": {
@@ -3924,7 +3660,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3938,14 +3673,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unified/-/unified-11.0.5.tgz",
       "integrity": "sha1-9mZ3YQpcCp7pDKsrjU1mA3Am2eE=",
       "license": "MIT",
       "dependencies": {
@@ -3964,7 +3697,6 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha1-0KP4by3Q23rNfYwkeAgLXGf5xqk=",
       "license": "MIT",
       "dependencies": {
@@ -3977,7 +3709,6 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha1-Z48gq1yhIHqX1+qKOINzyc+Ja+Q=",
       "license": "MIT",
       "dependencies": {
@@ -3990,7 +3721,6 @@
     },
     "node_modules/unist-util-position-from-estree": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
       "integrity": "sha1-2U2k31llKdH6o95QYgLwyaI/IgA=",
       "dev": true,
       "license": "MIT",
@@ -4004,7 +3734,6 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha1-RJxuIaiA4IVb9aq63rOnQDFKusI=",
       "license": "MIT",
       "dependencies": {
@@ -4017,7 +3746,6 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha1-mioosKp2oV4NpwoIpYY6LwYOJGg=",
       "license": "MIT",
       "dependencies": {
@@ -4032,7 +3760,6 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha1-d333+5hlLOFrS3zZmdChpA76OgI=",
       "license": "MIT",
       "dependencies": {
@@ -4046,7 +3773,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -4077,7 +3803,6 @@
     },
     "node_modules/vfile": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha1-NlKrHEllMYUr9VprrFevmB68OKs=",
       "license": "MIT",
       "dependencies": {
@@ -4091,7 +3816,6 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile-location/-/vfile-location-5.0.3.tgz",
       "integrity": "sha1-y56s0g8rZCbRlFHg6vo9CoRiJcM=",
       "license": "MIT",
       "dependencies": {
@@ -4105,7 +3829,6 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha1-h7RN3de3DwZBwuPtCGS6c+LqjfQ=",
       "license": "MIT",
       "dependencies": {
@@ -4119,7 +3842,6 @@
     },
     "node_modules/vite": {
       "version": "7.3.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-7.3.5.tgz",
       "integrity": "sha1-kMLQt7lKIk5+fc8i0pEv8LUpEWU=",
       "dev": true,
       "license": "MIT",
@@ -4194,7 +3916,6 @@
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha1-EBD/fGUOzLJZLOvur5obJT/UBpI=",
       "license": "MIT",
       "funding": {
@@ -4204,14 +3925,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "dev": true,
       "license": "ISC",
@@ -4227,7 +3946,6 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-3.25.76.tgz",
       "integrity": "sha1-JoQcP2/SKmonYOfMtxkXl2hHHjQ=",
       "dev": true,
       "license": "MIT",
@@ -4237,7 +3955,6 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha1-yCfUsKy3b8PmhaTG7CkC1RBw6dc=",
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
## Summary

Adds a project `.npmrc` with `omit-lockfile-registry-resolved=true` and regenerates the lockfile so registry feed URLs are not committed.

The regenerated lockfile removes 283 `resolved` fields. Dependency names, versions, integrity hashes, and platform metadata are unchanged.

## Validation

- `npx --yes -p node@22 -p npm@11.19.0 -c 'node --version && npm --version && npm config get omit-lockfile-registry-resolved'` returned Node `v22.23.2`, npm `11.19.0`, and `true`.
- A structural lockfile comparison found no changes outside `resolved`; no Microsoft feed URLs remain.
- Repeating `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` left SHA-256 `627473f314494ca7a47c5e3b53058b0054657daab4843c7e7f1b7a1b0654e823` unchanged.
- `npm ci --no-audit --no-fund` installed 233 packages.
- `npm run build` passed after transforming 1,176 modules and emitted the root page plus `dev-days/`, `dev-enablement-series/`, and `usage-based-billing/`.
